### PR TITLE
Use Keyword() so that sorting by the field works

### DIFF
--- a/elasticsearch_app/search.py
+++ b/elasticsearch_app/search.py
@@ -68,7 +68,7 @@ class LayerIndex(DocType):
         }
     )
     typename = Keyword()
-    title_sortable = Text()
+    title_sortable = Keyword()
     category = Keyword(
         fields={
             'text': field.Text(),
@@ -139,7 +139,7 @@ class MapIndex(DocType):
             'english': field.Text(analyzer='english')
         }
     )
-    title_sortable = Text()
+    title_sortable = Keyword()
     category = Keyword(
         fields={
             'text': field.Text(),
@@ -208,7 +208,7 @@ class DocumentIndex(DocType):
             'english': field.Text(analyzer='english')
         }
     )
-    title_sortable = Text()
+    title_sortable = Keyword()
     category = Keyword(
         fields={
             'text': field.Text(),
@@ -267,7 +267,7 @@ class GroupIndex(DocType):
             'english': field.Text(analyzer='english')
         }
     )
-    title_sortable = Text()
+    title_sortable = Keyword()
     description = Text()
     json = Text()
     type = Keyword(
@@ -316,7 +316,7 @@ class StoryIndex(DocType):
             'english': field.Text(analyzer='english')
         }
     )
-    title_sortable = Text()
+    title_sortable = Keyword()
     category = Keyword(
         fields={
             'text': field.Text(),


### PR DESCRIPTION
Text fields use a query-time in-memory data structure called fielddata which is disabled by default due to the heap space demand. Keyword field is preferred for sorting.