### PR TITLE
add profile to search

### DIFF
--- a/elasticsearch_app/signals.py
+++ b/elasticsearch_app/signals.py
@@ -31,40 +31,47 @@ if geonode_imported:
     @receiver(post_save, sender=Layer)
     def layer_index_post(sender, instance, **kwargs):
         index_object(instance, LayerIndex)
+        index_object(instance.owner, ProfileIndex)
 
     @receiver(post_save, sender=Service)
     def service_post_save(sender, **kwargs):
         service, created = kwargs["instance"], kwargs["created"]
         if not created:
             for instance in service.layer_set.all():
-                index_object(instance, LayerIndex)    
+                index_object(instance, LayerIndex)
+                index_object(instance.owner, ProfileIndex)  
         
     @receiver(post_delete, sender=Layer)
     def layer_index_delete(sender, instance, **kwargs):
         index_to_remove = LayerIndex.get(instance.id)
         if index_to_remove:
             index_to_remove.delete()
+        index_object(instance.owner, ProfileIndex)
 
 
     @receiver(post_save, sender=Map)
     def map_index_post(sender, instance, **kwargs):
         index_object(instance, MapIndex)
+        index_object(instance.owner, ProfileIndex)
 
     @receiver(post_delete, sender=Map)
     def map_index_delete(sender, instance, **kwargs):
         index_to_remove = MapIndex.get(instance.id)
         if index_to_remove:
             index_to_remove.delete()
+        index_object(instance.owner, ProfileIndex)
 
     @receiver(post_save, sender=Document)
     def document_index_post(sender, instance, **kwargs):
         index_object(instance, DocumentIndex)
+        index_object(instance.owner, ProfileIndex)
 
     @receiver(post_delete, sender=Document)
     def document_index_delete(sender, instance, **kwargs):
         index_to_remove = DocumentIndex.get(instance.id)
         if index_to_remove:
             index_to_remove.delete()
+        index_object(instance.owner, ProfileIndex)
 
     @receiver(post_save, sender=Profile)
     def profile_index_post(sender, instance, **kwargs):
@@ -85,6 +92,7 @@ if geonode_imported:
         index_to_remove = GroupIndex.get(instance.id)
         if index_to_remove:
             index_to_remove.delete()
+        index_object(instance.owner, ProfileIndex)
 
 # To extend this app in your project, add a post_save
 # signal for every model you wish to index.

--- a/elasticsearch_app/utils.py
+++ b/elasticsearch_app/utils.py
@@ -1,3 +1,5 @@
+from elasticsearch_app import search
+
 def index_object(object, index=None):
     '''
     Indexes an object into its appropriate model index.
@@ -7,7 +9,10 @@ def index_object(object, index=None):
     :param index: The search index to put the object in
     :return: A dict of the successfully indexed object
     '''
-    if hasattr(object, 'indexing'):
+    classname = object.__class__.__name__
+    if classname == 'Profile':
+        return search.create_profile_index(object)
+    elif hasattr(object, 'indexing'):
         return object.indexing()
     else:
         if index is not None:


### PR DESCRIPTION
This adds items to allow search against profiles. This PR also adds the example for Profiles to be used to remove elastic indexing function from models directly in geonode to allow for this app to be more fully separated from requiring changes to Geonode.

This PR will be followed by and require PRs to boundlessgeo/geonode and boundlessgeo/exchange as well.