### PR TITLE
[PSBEX-121] Only return the resource title, not including any remote service titl…

### DIFF
--- a/elasticsearch_app/search.py
+++ b/elasticsearch_app/search.py
@@ -140,15 +140,7 @@ def prepare_source_host(resource):
 
 
 def prepare_title(resource):
-    try:
-        resource_service = resource.service
-    except ObjectDoesNotExist:
-        resource_service = None
-
-    if resource_service is not None:
-        return '{} {}'.format(resource.service.title.strip(), resource.title)
-    else:
-        return resource.title
+    return resource.title
 
 
 def prepare_references(resource):


### PR DESCRIPTION
…e, for consistency with Exchange

This resolves inconsistencies with the remote service title sometimes showing up in addition to the layer's title, but other times not showing up this way in Exchange and its javascript clients.