### PR TITLE
Service category search

### DIFF
--- a/elasticsearch_app/search.py
+++ b/elasticsearch_app/search.py
@@ -95,10 +95,10 @@ def prepare_title_sortable(resource):
 def prepare_category(resource):
     if resource.category:
         return resource.category.identifier
-    elif resource.service and resource.service.category:
-        return resource.service.category.identifier
-    else:
-        return None
+    elif resource.service: 
+        if resource.service.category:
+            return resource.service.category.identifier
+    return None
 
 
 def prepare_category_gn_description(resource):

--- a/elasticsearch_app/search.py
+++ b/elasticsearch_app/search.py
@@ -95,9 +95,12 @@ def prepare_title_sortable(resource):
 def prepare_category(resource):
     if resource.category:
         return resource.category.identifier
-    elif resource.service: 
-        if resource.service.category:
-            return resource.service.category.identifier
+    try:
+        if resource.service is not None:
+            if resource.service.category is not None:
+                return resource.service.category.identifier
+    except ObjectDoesNotExist:
+        pass
     return None
 
 

--- a/elasticsearch_app/search.py
+++ b/elasticsearch_app/search.py
@@ -95,6 +95,8 @@ def prepare_title_sortable(resource):
 def prepare_category(resource):
     if resource.category:
         return resource.category.identifier
+    elif resource.service and resource.service.category:
+        return resource.service.category.identifier
     else:
         return None
 


### PR DESCRIPTION
Referencing service was leading to ObjectDoesNotExist error on the tests. This uses a try block to avoid.